### PR TITLE
Wire up functions for static site deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 *.ez
 /.vagrant
 /nginx_config_dir
+/workdir

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,7 @@
 
 Vagrant.configure(2) do |config|
 
-  config.vm.network "forwarded_port", guest: 80, host: 2000
-  config.vm.network "forwarded_port", guest: 8000, host: 2001
+  config.vm.network "private_network", ip: "192.168.88.88"
 
   config.vm.box = "hashicorp/precise64"
   config.vm.provision "shell", inline: <<-SHELL

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,12 +6,12 @@ use Mix.Config
 config :dockup,
   port: "8000",
   bind: "0.0.0.0",
-  workdir: "./workdir",
+  workdir: "workdir",
   cache_container: "cache",
   cache_volume: "/cache",
   github_webhook_secret: nil,
   command_module: Dockup.ShellCommand,
-  nginx_config_dir: "./nginx_config_dir",
+  nginx_config_dir: "nginx_config_dir",
   domain: "127.0.0.1.xip.io",
   start_server: true
 #

--- a/lib/dockup/container.ex
+++ b/lib/dockup/container.ex
@@ -31,7 +31,7 @@ defmodule Dockup.Container do
         Logger.info "Trying to pull nginx image"
         {_output, 0} = command.run("docker", ["run", "--name", "nginx",
           "-d", "-p", "80:80",
-          "-v", "#{Dockup.Configs.nginx_config_dir}:/etc/nginx/sites-enabled",
+          "-v", "#{Dockup.Configs.nginx_config_dir}:/etc/nginx/conf.d",
           "-v", "#{Dockup.Configs.workdir}:/dockup:ro",
           "nginx:1.8"])
       end

--- a/lib/dockup/deploy_job.ex
+++ b/lib/dockup/deploy_job.ex
@@ -22,7 +22,9 @@ defmodule Dockup.DeployJob do
   end
 
   defp deploy(:static_site, project_id) do
-    # TODO
+    Logger.info "Deploying static site #{project_id}"
+    Dockup.NginxConfig.write_config(:static_site, project_id)
+    Dockup.Container.reload_nginx
   end
 
   defp deploy(_, app_id) do

--- a/lib/dockup/haikunator.ex
+++ b/lib/dockup/haikunator.ex
@@ -1,6 +1,6 @@
 defmodule Dockup.Haikunator do
   def haiku_subdomain(adjectives, nouns) do
-    random_number_as_string = Enum.random(0..9999) |> Integer.to_string |> String.rjust 4, ?0
+    random_number_as_string = Enum.random(0..9999) |> Integer.to_string |> String.rjust(4, ?0)
     "#{Enum.random(adjectives)}-#{Enum.random(nouns)}-#{random_number_as_string}"
   end
 

--- a/lib/dockup/nginx_config.ex
+++ b/lib/dockup/nginx_config.ex
@@ -21,8 +21,9 @@ defmodule Dockup.NginxConfig do
   end
 
   def write_config(:static_site, project_id, haikunator \\ Dockup.Haikunator) do
-    Logger.info "Writing nginx config for #{project_id}"
-    config = static_site_config(project_id, haikunator.haikunated_url)
+    url = haikunator.haikunated_url
+    Logger.info "Writing nginx config to serve #{project_id} at http://#{url}"
+    config = static_site_config(project_id, url)
     File.write(config_file(project_id), config)
   end
 end

--- a/lib/dockup/nginx_config.ex
+++ b/lib/dockup/nginx_config.ex
@@ -1,4 +1,5 @@
 defmodule Dockup.NginxConfig do
+  require Logger
   def static_site_config(project_id, url) do
     """
     server {
@@ -25,6 +26,7 @@ defmodule Dockup.NginxConfig do
   end
 
   def write_config(:static_site, project_id, haikunator \\ Dockup.Haikunator) do
+    Logger.info "Writing nginx config for #{project_id}"
     config = static_site_config(project_id, haikunator.haikunated_url)
     File.write(config_file(project_id), config)
   end

--- a/lib/dockup/nginx_config.ex
+++ b/lib/dockup/nginx_config.ex
@@ -5,14 +5,9 @@ defmodule Dockup.NginxConfig do
     server {
       listen 80;
 
+      server_name #{url};
       root /dockup/#{project_id};
       index index.html;
-
-      server_name #{url};
-
-      location / {
-        try_files $uri $uri/ =404;
-      }
     }
     """
   end
@@ -22,7 +17,7 @@ defmodule Dockup.NginxConfig do
   end
 
   def config_file(project_id) do
-    Path.join(Dockup.Configs.nginx_config_dir, hash(project_id))
+    Path.join(Dockup.Configs.nginx_config_dir, "#{hash(project_id)}.conf")
   end
 
   def write_config(:static_site, project_id, haikunator \\ Dockup.Haikunator) do

--- a/lib/dockup/project.ex
+++ b/lib/dockup/project.ex
@@ -2,10 +2,11 @@ defmodule Dockup.Project do
   require Logger
 
   def clone_repository(repository, branch, command \\ Dockup.Command) do
-    workdir = project_id(repository, branch) |> workdir
-    Logger.info "Cloning #{repository} : #{branch} into #{workdir}"
-    File.mkdir_p!(workdir)
-    case command.run("git", ["clone", "--branch=#{branch}", "--depth=1", repository, workdir]) do
+    project_dir = project_id(repository, branch) |> project_dir
+    Logger.info "Cloning #{repository} : #{branch} into #{project_dir}"
+    File.rm_rf(project_dir)
+    File.mkdir_p!(project_dir)
+    case command.run("git", ["clone", "--branch=#{branch}", "--depth=1", repository, project_dir]) do
       {_out, 0} -> :ok
       {out, _} -> raise out
     end
@@ -19,13 +20,13 @@ defmodule Dockup.Project do
     "#{org}/#{repo}/#{branch}"
   end
 
-  def workdir(project_id) do
+  def project_dir(project_id) do
     "#{Dockup.Configs.workdir}/#{project_id}"
   end
 
   def auto_detect_project_type(project_id) do
     {:ok, cwd} = File.cwd
-    File.cd workdir(project_id)
+    File.cd project_dir(project_id)
     project_type = cond do
       static_site? -> :static_site
       # Rails etc can be auto detected in the future

--- a/lib/dockup/shell_command.ex
+++ b/lib/dockup/shell_command.ex
@@ -3,6 +3,6 @@ defmodule Dockup.ShellCommand do
   def run(command, args) do
     {out, exit_status} = System.cmd(command, args)
     Logger.info "Output of command #{command} with args #{inspect args}: #{out}"
-    {out, exit_status}
+    {String.strip(out), exit_status}
   end
 end

--- a/test/dockup/deploy_job_test.exs
+++ b/test/dockup/deploy_job_test.exs
@@ -1,0 +1,24 @@
+defmodule Dockup.DeployJobTest do
+  use ExUnit.Case
+
+  test "deploying static site writes nginx config and reloads nginx container" do
+    defmodule FakeProject do
+      def project_id("fake_repo", "fake_branch"), do: "fake_project_id"
+      def clone_repository(_repo, _branch), do: :ok
+      def auto_detect_project_type("fake_project_id"), do: :static_site
+    end
+
+    defmodule FakeNginxConfig do
+      def write_config(:static_site, "fake_project_id"), do: send self, :nginx_config_added
+    end
+
+    defmodule FakeContainer do
+      def reload_nginx, do: send self, :nginx_reloaded
+    end
+
+    Dockup.DeployJob.perform("fake_repo", "fake_branch", "fake_callback_url",
+                             FakeProject, FakeNginxConfig, FakeContainer)
+    assert_received :nginx_config_added
+    assert_received :nginx_reloaded
+  end
+end

--- a/test/dockup/nginx_config_test.exs
+++ b/test/dockup/nginx_config_test.exs
@@ -12,14 +12,9 @@ defmodule Dockup.NginxConfigTest do
     server {
       listen 80;
 
+      server_name haikunated_url;
       root /dockup/hello/world;
       index index.html;
-
-      server_name haikunated_url;
-
-      location / {
-        try_files $uri $uri/ =404;
-      }
     }
     """
     File.rm_rf Dockup.Configs.nginx_config_dir

--- a/test/dockup/project_test.exs
+++ b/test/dockup/project_test.exs
@@ -16,15 +16,15 @@ defmodule Dockup.ProjectTest do
     assert id == "code-mancers/dockup/master"
   end
 
-  test "workdir of a project is <Dockup workdir>/<project_id>" do
-    assert Dockup.Project.workdir("foo/test/baz") == "#{Dockup.Configs.workdir}/foo/test/baz"
+  test "project_dir of a project is <Dockup workdir>/<project_id>" do
+    assert Dockup.Project.project_dir("foo/test/baz") == "#{Dockup.Configs.workdir}/foo/test/baz"
   end
 
   # Remove mocking in favor of dependency injection and make this test pass
-  test "clone_repository clones the given branch of git repository into workdir" do
+  test "clone_repository clones the given branch of git repository into project_dir" do
     repository = "https://github.com/code-mancers/dockup.git"
     branch = "master"
-    workdir = Dockup.Project.project_id(repository, branch) |> Dockup.Project.workdir
+    project_dir = Dockup.Project.project_id(repository, branch) |> Dockup.Project.project_dir
 
     defmodule GitCloneCommand do
       def run(cmd, args) do
@@ -33,7 +33,7 @@ defmodule Dockup.ProjectTest do
       end
     end
     Dockup.Project.clone_repository(repository, branch, GitCloneCommand)
-    [cmd | args] = String.split("git clone --branch=master --depth=1 #{repository} #{workdir}")
+    [cmd | args] = String.split("git clone --branch=master --depth=1 #{repository} #{project_dir}")
 
     receive do
       {command, arguments} ->
@@ -62,7 +62,7 @@ defmodule Dockup.ProjectTest do
 
   test "auto_detect_project_type returns :static_site if index.html is found" do
     project_id = "auto/detect/static"
-    project_dir = Dockup.Project.workdir project_id
+    project_dir = Dockup.Project.project_dir project_id
     File.mkdir_p project_dir
     File.touch "#{project_dir}/index.html"
 
@@ -72,7 +72,7 @@ defmodule Dockup.ProjectTest do
 
   test "auto_detect_project_type returns :unknown if auto detection fails" do
     project_id = "auto/detect/none"
-    project_dir = Dockup.Project.workdir project_id
+    project_dir = Dockup.Project.project_dir project_id
     File.mkdir_p project_dir
 
     assert Dockup.Project.auto_detect_project_type(project_id) == :unknown


### PR DESCRIPTION
How to test:
```
# Start app inside vagrant
1. vagrant up
2. cd /vagrant
3. DOCKUP_DOMAIN=192.168.88.88.xip.io DOCKUP_WORKDIR=/vagrant/workdir DOCKUP_NGINX_CONFIG_DIR=/vagrant/nginx_config_dir iex -S mix
```

```
# From host, send a request to app running in vagrant
curl -XPOST  -d '{"repository":"https://github.com/syui/hugo-theme-air.git","branch":"gh-pages","callback_url":"fake_callback"}' -H "Content-Type: application/json" http://192.168.88.88:8000/deploy
```

Look for haikunated URL in the logs in iex running inside vagrant, visit the URL and verify that you can see the static site on the URL.

Closes #12 