### PR TITLE
Add Dockerfile to build dockup image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 /nginx_config_dir
 /workdir
 /projects.dets
+/.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM elixir:1.2.5
+
+# Install docker and docker-compose
+RUN curl -sSL https://get.docker.com/ | sh
+RUN sh -c "curl -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose"
+RUN chmod +x /usr/local/bin/docker-compose
+
+RUN mkdir -p /dockup
+WORKDIR /dockup
+COPY . ./
+COPY ./apps/dockup_ui/config/prod.secret.example.exs apps/dockup_ui/config/prod.secret.exs
+
+ENV MIX_ENV prod
+ENV PORT 4000
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+RUN mix deps.get --force --only prod
+RUN mix compile
+
+# Precompile DockupUi assets
+WORKDIR /dockup/apps/dockup_ui
+RUN wget -qO- https://deb.nodesource.com/setup_6.x | bash
+RUN apt-get update && apt-get install -y nodejs build-essential
+RUN npm install
+RUN ./node_modules/brunch/bin/brunch build --production
+RUN mix phoenix.digest
+
+WORKDIR /dockup
+EXPOSE 4000
+
+CMD ["mix", "phoenix.server"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Other goals:
 3. Ability to write a check to see if app is up
 4. Ability to deploy static sites
 
+## Installation
+
+Make sure you have docker, then run:
+
+    docker run -v /var/run/docker.sock:/var/run/docker.sock -p 4000:4000 codemancers/dockup
+
+Dockup is now accessible at `http://<host>:4000`
+
 ## Development
 
 Clone the repo and run:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure(2) do |config|
 
-  config.vm.network "private_network", ip: "192.168.88.88"
+  config.vm.network "forwarded_port", guest: 4000, host: 4000
 
   config.vm.box = "ubuntu/trusty64"
   config.vm.provision "shell", inline: <<-SHELL

--- a/apps/dockup_ui/config/prod.secret.example.exs
+++ b/apps/dockup_ui/config/prod.secret.example.exs
@@ -1,0 +1,13 @@
+use Mix.Config
+
+# In this file, we keep production configuration that
+# you likely want to automate and keep it away from
+# your version control system.
+config :dockup_ui, DockupUi.Endpoint,
+  secret_key_base: "tSzvLqPuzu78hCZ7htMXPlJX+qeC18HqfyfwxbSdY2LeVfIJxXlE1/BxnYIEvsH+"
+
+# Configure your database
+config :dockup_ui, DockupUi.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  database: "dockup_ui_prod",
+  pool_size: 20


### PR DESCRIPTION
I've set up auto build of docker image `codemancers/dockup` on dockerhub : https://hub.docker.com/r/codemancers/dockup/ . By mounting the docker daemon unix socket inside the dockup's docker container, we can issue commands to docker daemon running on host from within the client. How this helps - setting up dockup is now a single command as documented in the README. Big win!

Closes #32 