### PR TITLE
Add ability to whitelist git urls

### DIFF
--- a/apps/dockup/lib/dockup/configs.ex
+++ b/apps/dockup/lib/dockup/configs.ex
@@ -24,6 +24,15 @@ defmodule Dockup.Configs do
     System.get_env("DOCKUP_DOMAIN") || Application.fetch_env!(:dockup, :domain)
   end
 
+  def whitelist_all? do
+    env_var = System.get_env("DOCKUP_WHITELIST_ALL")
+    if env_var do
+      env_var == "true"
+    else
+      Application.fetch_env(:dockup, :whitelist_all) == {:ok, true}
+    end
+  end
+
   defp ensure_dir_exists(dir) do
     unless File.exists?(dir) do
       Logger.info "Creating missing directory: #{dir}"

--- a/apps/dockup/lib/dockup/deploy_job.ex
+++ b/apps/dockup/lib/dockup/deploy_job.ex
@@ -33,7 +33,7 @@ defmodule Dockup.DeployJob do
       Logger.error (inspect error)
       callback.("deployment_failed", (inspect error))
     e ->
-      message = "An unexpected error occured when deploying #{project_identifier} : #{e.message}"
+      message = "An error occured when deploying #{project_identifier} : #{e.message}"
       Logger.error message
       callback.("deployment_failed", message)
   end
@@ -56,6 +56,6 @@ defmodule Dockup.DeployJob do
   end
 
   defp log_url(project_id) do
-    %{ "log_url" => "/deployment_logs/#?projectName=#{project_id}" }
+    %{"log_url" => "/deployment_logs/#?projectName=#{project_id}"}
   end
 end

--- a/apps/dockup/lib/dockup/nginx_config.ex
+++ b/apps/dockup/lib/dockup/nginx_config.ex
@@ -62,11 +62,6 @@ defmodule Dockup.NginxConfig do
   Returns a URL with a random subdomain. The subdomain string starts with "d"
   and ends with "p", a naive workaround to ensure it starts and ends with
   alphanumerics.
-
-      iex> url = Dockup.NginxConfig.create_url
-      ...> domain = Dockup.Configs.domain
-      ...> url =~ ~r/d\\w{10}p.#\{domain}/
-      true
   """
   def create_url(len \\ 10) do
     random_string =

--- a/apps/dockup/lib/dockup/project.ex
+++ b/apps/dockup/lib/dockup/project.ex
@@ -37,12 +37,12 @@ defmodule Dockup.Project do
   # Waits until the urls all return expected HTTP status.
   # Currently, assuming that URLs are for static sites
   # and they return 200.
-  def wait_till_up(service_urls, http \\ __MODULE__, interval \\ 3000) do
+  def wait_till_up(service_urls, http \\ __MODULE__, interval \\ 5000) do
     service_urls
     |> Enum.reduce([], fn {_service, port_urls}, acc -> acc ++ Enum.map(port_urls, fn port_url_map -> {port_url_map["url"], 200}  end) end)
     |> Enum.each(fn {url, response} ->
-      # Retry 10 times in an interval of 3 seconds
-      retry 10 in interval do
+      # Retry 30 times in an interval of 5 seconds
+      retry 30 in interval do
         Logger.info "Checking if #{url} returns http satus #{response}"
         ^response = http.get_status(url)
       end

--- a/apps/dockup/lib/dockup/whitelist_store.ex
+++ b/apps/dockup/lib/dockup/whitelist_store.ex
@@ -1,0 +1,44 @@
+defmodule Dockup.WhitelistStore do
+  require Logger
+  @moduledoc """
+  This module is responsible for loading a list of whitelisted git urls
+  from a file and providing functions to check if a URL is whitelisted or not.
+  """
+
+  def start_link(name \\ __MODULE__) do
+    Agent.start_link(__MODULE__, :get_urls, [], name: name)
+  end
+
+  @doc """
+  Returns true if git url is whitelisted
+  """
+  def whitelisted?(git_url, name \\ __MODULE__) do
+    Dockup.Configs.whitelist_all? || whitelisted_url?(git_url, name)
+  end
+
+  def whitelist_file do
+    Path.join(Dockup.Configs.workdir, "whitelisted_urls")
+  end
+
+  def get_urls do
+    urls =
+      whitelist_file
+      |> File.read!
+      |> String.split
+    Logger.info "Whitelisted Git URLs: #{inspect urls}"
+    urls
+  rescue
+    _e ->
+      Logger.warn "Cannot load #{whitelist_file}"
+      []
+  end
+
+  defp whitelisted_url?(git_url, name) do
+    if Process.whereis(name) do
+      Agent.get(name, fn urls -> git_url in urls end)
+    else
+      Logger.error "WhitelistStore agent is not running."
+      false
+    end
+  end
+end

--- a/apps/dockup/test/dockup/deploy_job_test.exs
+++ b/apps/dockup/test/dockup/deploy_job_test.exs
@@ -20,6 +20,8 @@ defmodule Dockup.DeployJobTest do
   end
 
   defmodule FakeDeployJob do
+    def ensure_whitelisted!("fake_repo"), do: :ok
+
     def deploy(:static_site, "123") do
       "fake_urls"
     end
@@ -36,12 +38,13 @@ defmodule Dockup.DeployJobTest do
 
   test "triggers deployment_failed callback when an exception occurs" do
     defmodule FailingDeployJob do
+      def ensure_whitelisted!("fake_repo"), do: true
       def deploy(:static_site, "123") do
         raise "ifuckedup"
       end
     end
     Dockup.DeployJob.perform(123, "fake_repo", "fake_branch", FakeCallback.lambda,
                             project: FakeProject, deploy_job: FailingDeployJob)
-    assert_received {"deployment_failed", "An unexpected error occured when deploying 123 : ifuckedup"}
+    assert_received {"deployment_failed", "An error occured when deploying 123 : ifuckedup"}
   end
 end

--- a/apps/dockup/test/dockup/whitelist_store_test.exs
+++ b/apps/dockup/test/dockup/whitelist_store_test.exs
@@ -1,0 +1,22 @@
+defmodule Dockup.WhitelistStoreTest do
+  use ExUnit.Case, async: true
+
+  alias Dockup.WhitelistStore
+
+  @store_name :test_whitelist_store
+
+  test "when file doesn't exist" do
+    {:ok, _pid} = WhitelistStore.start_link(@store_name)
+    refute WhitelistStore.whitelisted?("random", @store_name)
+  end
+
+  test "when file exists" do
+    File.write!(WhitelistStore.whitelist_file, "foo\nbar")
+    {:ok, _pid} = WhitelistStore.start_link(@store_name)
+    assert WhitelistStore.whitelisted?("foo", @store_name)
+    assert WhitelistStore.whitelisted?("bar", @store_name)
+    refute WhitelistStore.whitelisted?("baz", @store_name)
+    File.rm(WhitelistStore.whitelist_file)
+  end
+end
+

--- a/apps/dockup_ui/web/models/deployment.ex
+++ b/apps/dockup_ui/web/models/deployment.ex
@@ -37,9 +37,21 @@ defmodule DockupUi.Deployment do
   @doc """
   This changeset is used when creating a deployment
   """
-  def create_changeset(model, params \\ :empty) do
+  def create_changeset(model, params, whitelist_store) do
     required_fields = ~w(git_url branch)
     optional_fields = ~w(callback_url)
-    model |> cast(params, required_fields, optional_fields)
+    model
+    |> cast(params, required_fields, optional_fields)
+    |> validate_whitelisted_git_url(whitelist_store)
+  end
+
+  # Check if git URL is whitelisted
+  defp validate_whitelisted_git_url(changeset, whitelist_store) do
+    git_url = get_field(changeset, :git_url)
+    if whitelist_store.whitelisted?(git_url) do
+      changeset
+    else
+      add_error(changeset, :git_url, "is not whitelisted for deployment")
+    end
   end
 end

--- a/apps/dockup_ui/web/services/deploy_service.ex
+++ b/apps/dockup_ui/web/services/deploy_service.ex
@@ -4,9 +4,9 @@ defmodule DockupUi.DeployService do
     Repo
   }
 
-  def run(deployment_params, deploy_job \\ Dockup.DeployJob) do
+  def run(deployment_params, deploy_job \\ Dockup.DeployJob, whitelist_store \\ Dockup.WhitelistStore) do
     with \
-      changeset <- Deployment.create_changeset(%Deployment{status: "queued"}, deployment_params),
+      changeset <- Deployment.create_changeset(%Deployment{status: "queued"}, deployment_params, whitelist_store),
       {:ok, deployment} <- Repo.insert(changeset),
       :ok <- deploy_project(deploy_job, deployment),
       :ok <- DockupUi.DeploymentChannel.new_deployment(deployment)

--- a/apps/dockup_ui/web/static/js/components/github_url_input.js
+++ b/apps/dockup_ui/web/static/js/components/github_url_input.js
@@ -23,7 +23,7 @@ class GithubUrlInput extends Component {
   }
 
   updateUrl(org, repo) {
-    this.props.onUrlChange(`https://github.com/${org}/${repo}`);
+    this.props.onUrlChange(`https://github.com/${org}/${repo}.git`);
   }
 
   render() {


### PR DESCRIPTION
This way, random deployments with potential for accessing host machine can be avoided.
The whitelisted git urls are to be added in the file "whitelisted_urls" in Dockup's workdir.