### PR TITLE
Fixed failing script

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -2,5 +2,5 @@
 
 mix do local.hex, deps.get, compile
 cd apps/dockup_ui && npm install
-mix do ecto.drop, ecto.create, mix ecto.migrate
+mix ecto.reset
 cd ../..


### PR DESCRIPTION
Running script gave the error:
** (Mix) The task "mix" could not be found

Used ecto.reset alias