### PR TITLE
increase timeout to 8 mins

### DIFF
--- a/apps/dockup/lib/dockup/project.ex
+++ b/apps/dockup/lib/dockup/project.ex
@@ -44,8 +44,8 @@ defmodule Dockup.Project do
       url = url <> root_path(project_id)
       response = http_status(project_id)
 
-      # Retry 60 times in an interval of 5 seconds
-      retry 60 in interval do
+      # Retry 100 times in an interval of 5 seconds ~ 8 mins
+      retry 100 in interval do
         Logger.info "Checking if #{url} returns http satus #{response}"
         ^response = http.get_status(url)
       end


### PR DESCRIPTION
Sometimes, retries are running out even though container is seeding and booting up

```
11:46:47.733 [info] Checking if zfsrmujxtp.dockup.test.in/ returns http satus 301
11:46:47.737 [info] Attempt 57 failed because of error: %MatchError{term: 503}
11:46:50.353 [info] Checking if bxlkayhfms.dockup.test.in/ returns http satus 301
11:46:50.373 [info] Attempt 59 failed because of error: %MatchError{term: 503}
11:46:52.738 [info] Checking if zfsrmujxtp.dockup.test.in/ returns http satus 301
11:46:52.755 [info] Attempt 58 failed because of error: %MatchError{term: 503}
11:46:55.373 [info] Checking if bxlkayhfms.dockup.test.in/ returns http satus 301
11:46:55.384 [info] Attempt 60 failed because of error: %MatchError{term: 503}
11:46:57.757 [info] Checking if zfsrmujxtp.dockup.test.in/ returns http satus 301
11:46:57.763 [info] Attempt 59 failed because of error: %MatchError{term: 503}
```