### PR TITLE
[#180] Trim whitespaces from submitted branch name

### DIFF
--- a/apps/dockup_ui/web/static/js/components/deployment_form.js
+++ b/apps/dockup_ui/web/static/js/components/deployment_form.js
@@ -64,7 +64,7 @@ class DeploymentForm extends Component {
   }
 
   handleBranchChange(branch) {
-    this.setState({branch: branch});
+    this.setState({branch: branch.trim()});
   }
 
   validInputs() {


### PR DESCRIPTION
Fixes #180.

- Trims the branch name which is submitted, hence preventing clone failures. 