### PR TITLE
Consider "starting" state as currently active deployment

### DIFF
--- a/apps/dockup_ui/lib/dockup_ui/callback.ex
+++ b/apps/dockup_ui/lib/dockup_ui/callback.ex
@@ -35,6 +35,9 @@ defmodule DockupUi.Callback do
       "deleted" ->
         process_deployment_queue(deployment_queue)
 
+      "hibernated" ->
+        process_deployment_queue(deployment_queue)
+
       _ ->
         :ok
     end

--- a/apps/dockup_ui/lib/dockup_ui/deployment_queue.ex
+++ b/apps/dockup_ui/lib/dockup_ui/deployment_queue.ex
@@ -87,17 +87,22 @@ defmodule DockupUi.DeploymentQueue do
   end
 
   defp has_capacity_to_deploy? do
+    current_deployment_count = current_deployment_count()
+    max_concurrent_deployments = max_concurrent_deployments()
+    current_build_count = current_build_count()
+    max_concurrent_builds = max_concurrent_builds()
+
     # Useful for debugging queueing issues
     Logger.info(
       "Processing queue -
-      current_deployment_count(#{current_deployment_count()})
-      max_concurrent_deployments(#{max_concurrent_deployments()})
-      current_build_count(#{current_build_count()})
-      max_concurrent_builds(#{max_concurrent_builds()})"
+      current_deployment_count(#{current_deployment_count})
+      max_concurrent_deployments(#{max_concurrent_deployments})
+      current_build_count(#{current_build_count})
+      max_concurrent_builds(#{max_concurrent_builds})"
     )
 
-    current_deployment_count() < max_concurrent_deployments() &&
-      current_build_count() < max_concurrent_builds()
+    current_deployment_count < max_concurrent_deployments &&
+      current_build_count < max_concurrent_builds
   end
 
   defp deploy_from_queue(queue, backend, callback_module) do
@@ -124,7 +129,7 @@ defmodule DockupUi.DeploymentQueue do
     query =
       from(
         d in Deployment,
-        where: d.status not in ["queued", "deleted", "hibernated", "starting"]
+        where: d.status not in ["queued", "deleted", "hibernated"]
       )
 
     Repo.aggregate(query, :count, :id)

--- a/apps/dockup_ui/test/lib/deployment_queue_test.exs
+++ b/apps/dockup_ui/test/lib/deployment_queue_test.exs
@@ -50,7 +50,7 @@ defmodule DockupUi.DeploymentQueueTest do
   end
 
   test "deploys from tail of queue when there aren't enough concurrent deployments" do
-    for _ <- 1..4 do
+    for _ <- 1..3 do
       insert(:deployment, status: "started")
     end
     for _ <- 1..4 do


### PR DESCRIPTION
This will prevent overflowing max concurrent deployments. This PR also makes hibernating trigger the deployment queue processing.

Fixes #199 